### PR TITLE
Handle report-level errors on initial request for scheduled reports

### DIFF
--- a/kardia-tools/send-reports/send_reports/__main__.py
+++ b/kardia-tools/send-reports/send_reports/__main__.py
@@ -101,7 +101,11 @@ try:
     report_sender = EmailReportSender(config["email"]["smtp"])
 
     scheduled_report_filters = _get_scheduled_report_filters()
-    scheduled_reports = kardia_client.get_scheduled_reports_to_be_sent(scheduled_report_filters)
+
+    on_individual_report_error = lambda report_id: _handle_error((f"Error getting information for scheduled report "
+        f"{report_id} from Kardia, continuing on to next scheduled report..."), False)
+    scheduled_reports = kardia_client.get_scheduled_reports_to_be_sent(scheduled_report_filters,
+        on_individual_report_error)
 
     # If there are no scheduled reports to be sent, just exit now
     if not scheduled_reports:

--- a/kardia-tools/send-reports/send_reports/kardia_clients/kardia_client.py
+++ b/kardia-tools/send-reports/send_reports/kardia_clients/kardia_client.py
@@ -1,7 +1,7 @@
 import abc
 from send_reports.models import KardiaUserAgent, OSMLPath, ScheduledReport, ScheduledReportFilters, \
     ScheduledReportParam, SendingInfo, SentStatus
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 class KardiaClient(abc.ABC):
 
@@ -10,7 +10,8 @@ class KardiaClient(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_scheduled_reports_to_be_sent(self, filters: ScheduledReportFilters) -> List[ScheduledReport]:
+    def get_scheduled_reports_to_be_sent(self, filters: ScheduledReportFilters,
+        on_individual_report_error: Callable[[str], None]) -> List[ScheduledReport]:
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
Previously, if there was a problem requesting the initial information for any single report (for instance, a problem getting its template file), NO reports would end up being processed. With these changes, if there's a problem getting a single report's information, it will be logged but the script will move on and continue trying to process the other reports. The problematic report will remain as "not sent" in the Kardia database.