### PR TITLE
Bugfix: recently added donor settings endpoint was nested at the wrong level

### DIFF
--- a/kardia-app/modules/rcpt/api_donor.qyt
+++ b/kardia-app/modules/rcpt/api_donor.qyt
@@ -413,21 +413,21 @@ api_donors "system/querytree"
 		    ";
 	    use_having = yes;
 	    }
-	}
 
-    Settings "system/querytree"
-        {
-        text = "Settings";
-
-        settings_list "system/querytree"
+        Settings "system/querytree"
             {
-            sql = " select
-                        *
-                    from
-                        identity /apps/kardia/data/Kardia_DB/p_donor/rows d
-                    where
-                        :d:p_partner_key = :donors:p_partner_key
-                    ";
+            text = "Settings";
+
+            settings_list "system/querytree"
+                {
+                sql = " select
+                            *
+                        from
+                            identity /apps/kardia/data/Kardia_DB/p_donor/rows d
+                        where
+                            :d:p_partner_key = :donors:p_partner_key
+                        ";
+                }
             }
         }
     }


### PR DESCRIPTION
Recently added /Settings endpoint should have been inside the donors object.  Fixed.