### PR TITLE
fixed edit button in the crm module never enabling

### DIFF
--- a/kardia-app/modules/crm/button_generic.cmp
+++ b/kardia-app/modules/crm/button_generic.cmp
@@ -63,7 +63,7 @@ button_generic "widget/component-decl"
 		disable_color="#334466";
 		background=null;
 		widget_class=crm_iconbutton;
-		enabled=runclient(:button_generic:enabled);
+		enabled=runclient(:enabled:value);
 		}
 	    number_label "widget/label"
 		{


### PR DESCRIPTION
The edit button appears to have stopped working due to a change to centrallix back in january (commit   eb50a5317895bd9a9e3167db57347895233f510f, "JS: fixes handling of not-yet-available OSRC properties")