### PR TITLE
Fix "null" and unpopulated fields

### DIFF
--- a/kardia-app/modules/base/new_partner.app
+++ b/kardia-app/modules/base/new_partner.app
@@ -17,8 +17,11 @@ new_partner "widget/page"
     set_given_name "widget/parameter" { type=string; }
     set_surname "widget/parameter" { type=string; }
     set_salutation "widget/parameter" { type=string; }
+    set_title "widget/parameter" { type=string; }
+    set_suffix "widget/parameter" { type=string; }
     set_addr1 "widget/parameter" { type=string; }
     set_addr2 "widget/parameter" { type=string; }
+    set_addr3 "widget/parameter" { type=string; }
     set_city "widget/parameter" { type=string; }
     set_state_province "widget/parameter" { type=string; }
     set_postal "widget/parameter" { type=string; }
@@ -42,8 +45,11 @@ new_partner "widget/page"
 	set_given_name=runserver(:this:set_given_name);
 	set_surname=runserver(:this:set_surname);
 	set_salutation=runserver(:this:set_salutation);
+	set_title=runserver(:this:set_title);
+	set_suffix=runserver(:this:set_suffix);
 	set_addr1=runserver(:this:set_addr1);
 	set_addr2=runserver(:this:set_addr2);
+	set_addr3=runserver(:this:set_addr3);
 	set_city=runserver(:this:set_city);
 	set_state_province=runserver(:this:set_state_province);
 	set_postal=runserver(:this:set_postal);

--- a/kardia-app/modules/base/new_partner.app
+++ b/kardia-app/modules/base/new_partner.app
@@ -28,6 +28,8 @@ new_partner "widget/page"
     set_country_code "widget/parameter" { type=string; }
     set_email "widget/parameter" { type=string; }
     set_phone "widget/parameter" { type=string; }
+    set_phone_area_city "widget/parameter" { type=string; }
+    set_phone_area_country "widget/parameter" { type=string; }
     set_comment "widget/parameter" { type=string; }
 
     new_partner_cmp "widget/component" 
@@ -56,6 +58,8 @@ new_partner "widget/page"
 	set_country_code=runserver(:this:set_country_code);
 	set_email=runserver(:this:set_email);
 	set_phone=runserver(:this:set_phone);
+	set_phone_area_city=runserver(:this:set_phone_area_city);
+	set_phone_area_country=runserver(:this:set_phone_area_country);
 	set_comment=runserver(:this:set_comment);
 	}
     }

--- a/kardia-app/modules/base/new_partner.cmp
+++ b/kardia-app/modules/base/new_partner.cmp
@@ -38,6 +38,7 @@ new_partner "widget/component-decl"
     set_email "widget/parameter" { type=string; deploy_to_client=yes; }
     set_phone "widget/parameter" { type=string; deploy_to_client=yes; }
     set_phone_area_city "widget/parameter" { type=string; deploy_to_client=yes; }
+    set_phone_area_country "widget/parameter" { type=string; deploy_to_client=yes; }
     set_comment "widget/parameter" { type=string; deploy_to_client=yes; }
 
     set_focus "widget/connector"
@@ -62,9 +63,9 @@ new_partner "widget/component-decl"
     set_country_code_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_country_code is not null); target=new_location_form; action=SetValue; Field=runclient("p_country_code"); Value=runclient(:new_partner:set_country_code); }
     set_email_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_email is not null); target=new_email_form; action=SetValue; Field=runclient("p_contact_data"); Value=runclient(:new_partner:set_email); }
     set_phone_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone is not null); target=new_phone_form; action=SetValue; Field=runclient("p_contact_data"); Value=runclient(:new_partner:set_phone); }
-    set_phone_area_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone_area_city is not null); target=new_phone_form; action=SetValue; Field=runclient("p_phone_area_city"); Value=runclient(:new_partner:set_phone_area_city); }
+    set_phone_area_city_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone_area_city is not null); target=new_phone_form; action=SetValue; Field=runclient("p_phone_area_city"); Value=runclient(:new_partner:set_phone_area_city); }
     set_phone_area_country_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone_area_country is not null); target=new_phone_form; action=SetValue; Field=runclient("p_phone_country"); Value=runclient(:new_partner:set_phone_area_country); }
-    set_phone_country_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone is not null and :new_partner:set_country_code = 'US'); target=new_phone_form; action=SetValue; Field=runclient("p_phone_country"); Value=runclient(1); }
+    set_phone_area_country_guess_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone is not null and :new_partner:set_phone_area_country is null and :new_partner:set_country_code = 'US'); target=new_phone_form; action=SetValue; Field=runclient("p_phone_country"); Value=runclient(1); }
 
     set_donor_cn "widget/connector"
 	{

--- a/kardia-app/modules/base/new_partner.cmp
+++ b/kardia-app/modules/base/new_partner.cmp
@@ -26,8 +26,11 @@ new_partner "widget/component-decl"
     set_given_name "widget/parameter" { type=string; deploy_to_client=yes; }
     set_surname "widget/parameter" { type=string; deploy_to_client=yes; }
     set_salutation "widget/parameter" { type=string; deploy_to_client=yes; }
+    set_title "widget/parameter" { type=string; deploy_to_client=yes; }
+    set_suffix "widget/parameter" { type=string; deploy_to_client=yes; }
     set_addr1 "widget/parameter" { type=string; deploy_to_client=yes; }
     set_addr2 "widget/parameter" { type=string; deploy_to_client=yes; }
+    set_addr3 "widget/parameter" { type=string; deploy_to_client=yes; }
     set_city "widget/parameter" { type=string; deploy_to_client=yes; }
     set_state_province "widget/parameter" { type=string; deploy_to_client=yes; }
     set_postal "widget/parameter" { type=string; deploy_to_client=yes; }
@@ -47,8 +50,11 @@ new_partner "widget/component-decl"
     set_surname_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_surname is not null); target=new_partner_form; action=SetValue; Field=runclient("p_surname"); Value=runclient(:new_partner:set_surname); }
     set_salutation_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_salutation is not null); target=new_partner_form; action=SetValue; Field=runclient("p_preferred_name"); Value=runclient(:new_partner:set_salutation); }
     set_comment_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_comment is not null); target=new_partner_form; action=SetValue; Field=runclient("p_comments"); Value=runclient(:new_partner:set_comment); }
+    set_title_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_title is not null); target=new_partner_form; action=SetValue; Field=runclient("p_title"); Value=runclient(:new_partner:set_title); }
+    set_suffix_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_suffix is not null); target=new_partner_form; action=SetValue; Field=runclient("p_suffix"); Value=runclient(:new_partner:set_suffix); }
     set_addr1_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_addr1 is not null); target=new_location_form; action=SetValue; Field=runclient("p_address_1"); Value=runclient(:new_partner:set_addr1); }
     set_addr2_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_addr2 is not null); target=new_location_form; action=SetValue; Field=runclient("p_address_2"); Value=runclient(:new_partner:set_addr2); }
+    set_addr3_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_addr3 is not null); target=new_location_form; action=SetValue; Field=runclient("p_address_3"); Value=runclient(:new_partner:set_addr3); }
     set_city_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_city is not null); target=new_location_form; action=SetValue; Field=runclient("p_city"); Value=runclient(:new_partner:set_city); }
     set_state_province_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_state_province is not null); target=new_location_form; action=SetValue; Field=runclient("p_state_province"); Value=runclient(:new_partner:set_state_province); }
     set_postal_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_postal is not null); target=new_location_form; action=SetValue; Field=runclient("p_postal_code"); Value=runclient(:new_partner:set_postal); }
@@ -780,4 +786,3 @@ new_partner "widget/component-decl"
 	    }
 	}
     }
-

--- a/kardia-app/modules/base/new_partner.cmp
+++ b/kardia-app/modules/base/new_partner.cmp
@@ -37,6 +37,7 @@ new_partner "widget/component-decl"
     set_country_code "widget/parameter" { type=string; deploy_to_client=yes; }
     set_email "widget/parameter" { type=string; deploy_to_client=yes; }
     set_phone "widget/parameter" { type=string; deploy_to_client=yes; }
+    set_phone_area_city "widget/parameter" { type=string; deploy_to_client=yes; }
     set_comment "widget/parameter" { type=string; deploy_to_client=yes; }
 
     set_focus "widget/connector"
@@ -61,6 +62,8 @@ new_partner "widget/component-decl"
     set_country_code_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_country_code is not null); target=new_location_form; action=SetValue; Field=runclient("p_country_code"); Value=runclient(:new_partner:set_country_code); }
     set_email_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_email is not null); target=new_email_form; action=SetValue; Field=runclient("p_contact_data"); Value=runclient(:new_partner:set_email); }
     set_phone_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone is not null); target=new_phone_form; action=SetValue; Field=runclient("p_contact_data"); Value=runclient(:new_partner:set_phone); }
+    set_phone_area_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone_area_city is not null); target=new_phone_form; action=SetValue; Field=runclient("p_phone_area_city"); Value=runclient(:new_partner:set_phone_area_city); }
+    set_phone_area_country_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone_area_country is not null); target=new_phone_form; action=SetValue; Field=runclient("p_phone_country"); Value=runclient(:new_partner:set_phone_area_country); }
     set_phone_country_cn "widget/connector" { event=LoadComplete; event_condition=runclient(:new_partner:set_phone is not null and :new_partner:set_country_code = 'US'); target=new_phone_form; action=SetValue; Field=runclient("p_phone_country"); Value=runclient(1); }
 
     set_donor_cn "widget/connector"

--- a/kardia-app/modules/rcpt/gift_import.cmp
+++ b/kardia-app/modules/rcpt/gift_import.cmp
@@ -326,6 +326,9 @@ gift_import "widget/component-decl"
 					:eg:i_eg_desig_notes,
 					:eg:i_eg_donor_email,
 					:eg:i_eg_donor_phone,
+					:eg:i_eg_donor_phone_line,
+					:eg:i_eg_donor_phone_area,
+					:eg:i_eg_donor_phone_country,
 					:eg:a_ledger_number,
 					:eg:i_eg_gift_uuid,
 					:eg:i_eg_trx_uuid,
@@ -562,7 +565,9 @@ gift_import "widget/component-decl"
 							    set_state_province = runclient(isnull(:gift_import_osrc:i_eg_donor_state, ""));
 							    set_postal = runclient(isnull(:gift_import_osrc:i_eg_donor_postal, ""));
 							    set_country_code = runclient(isnull(:gift_import_osrc:import_country_code, ""));
-							    set_phone = runclient(isnull(:gift_import_osrc:i_eg_donor_phone, ""));
+							    set_phone = runclient(isnull(:gift_import_osrc:i_eg_donor_phone_line, isnull(:gift_import_osrc:i_eg_donor_phone, "")));
+							    set_phone_area_city = runclient(isnull(:gift_import_osrc:i_eg_donor_phone_area, ""));
+							    set_phone_area_country = runclient(isnull(:gift_import_osrc:i_eg_donor_phone_country, ""));
 							    set_email = runclient(isnull(:gift_import_osrc:i_eg_donor_email, ""));
 							    }
 							}

--- a/kardia-app/modules/rcpt/gift_import.cmp
+++ b/kardia-app/modules/rcpt/gift_import.cmp
@@ -310,8 +310,11 @@ gift_import "widget/component-decl"
 					p_country_name = upper(:co:p_country_name),
 					:af:p_format,
 					:eg:i_eg_donor_name,
+					:eg:i_eg_donor_prefix,
+					:eg:i_eg_donor_suffix,
 					:eg:i_eg_donor_addr1,
 					:eg:i_eg_donor_addr2,
+					:eg:i_eg_donor_addr3,
 					:eg:i_eg_donor_city,
 					:eg:i_eg_donor_state,
 					:eg:i_eg_donor_postal,
@@ -550,8 +553,11 @@ gift_import "widget/component-decl"
 							    set_surname = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name)) + 2), null));
 							    set_given_name = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, 1, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name))), :gift_import_osrc:i_eg_donor_name));
 							    set_salutation = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, 1, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name))), :gift_import_osrc:i_eg_donor_name));
+							    set_title = runclient(isnull(:gift_import_osrc:i_eg_donor_prefix, ""));
+							    set_suffix = runclient(isnull(:gift_import_osrc:i_eg_donor_suffix, ""));
 							    set_addr1 = runclient(isnull(:gift_import_osrc:i_eg_donor_addr1, ""));
 							    set_addr2 = runclient(isnull(:gift_import_osrc:i_eg_donor_addr2, ""));
+							    set_addr3 = runclient(isnull(:gift_import_osrc:i_eg_donor_addr3, ""));
 							    set_city = runclient(isnull(:gift_import_osrc:i_eg_donor_city, ""));
 							    set_state_province = runclient(isnull(:gift_import_osrc:i_eg_donor_state, ""));
 							    set_postal = runclient(isnull(:gift_import_osrc:i_eg_donor_postal, ""));

--- a/kardia-app/modules/rcpt/gift_import.cmp
+++ b/kardia-app/modules/rcpt/gift_import.cmp
@@ -550,14 +550,14 @@ gift_import "widget/component-decl"
 							    set_surname = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name)) + 2), null));
 							    set_given_name = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, 1, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name))), :gift_import_osrc:i_eg_donor_name));
 							    set_salutation = runclient(condition(charindex(' ',:gift_import_osrc:i_eg_donor_name) > 0, substring(:gift_import_osrc:i_eg_donor_name, 1, char_length(:gift_import_osrc:i_eg_donor_name) - charindex(' ',reverse(:gift_import_osrc:i_eg_donor_name))), :gift_import_osrc:i_eg_donor_name));
-							    set_addr1 = runclient(:gift_import_osrc:i_eg_donor_addr1);
-							    set_addr2 = runclient(:gift_import_osrc:i_eg_donor_addr2);
-							    set_city = runclient(:gift_import_osrc:i_eg_donor_city);
-							    set_state_province = runclient(:gift_import_osrc:i_eg_donor_state);
-							    set_postal = runclient(:gift_import_osrc:i_eg_donor_postal);
-							    set_country_code = runclient(:gift_import_osrc:import_country_code);
-							    set_phone = runclient(:gift_import_osrc:i_eg_donor_phone);
-							    set_email = runclient(:gift_import_osrc:i_eg_donor_email);
+							    set_addr1 = runclient(isnull(:gift_import_osrc:i_eg_donor_addr1, ""));
+							    set_addr2 = runclient(isnull(:gift_import_osrc:i_eg_donor_addr2, ""));
+							    set_city = runclient(isnull(:gift_import_osrc:i_eg_donor_city, ""));
+							    set_state_province = runclient(isnull(:gift_import_osrc:i_eg_donor_state, ""));
+							    set_postal = runclient(isnull(:gift_import_osrc:i_eg_donor_postal, ""));
+							    set_country_code = runclient(isnull(:gift_import_osrc:import_country_code, ""));
+							    set_phone = runclient(isnull(:gift_import_osrc:i_eg_donor_phone, ""));
+							    set_email = runclient(isnull(:gift_import_osrc:i_eg_donor_email, ""));
 							    }
 							}
 						    }
@@ -2425,4 +2425,3 @@ gift_import "widget/component-decl"
 	    }
 	}
     }
-


### PR DESCRIPTION
Fix blank fields being populated with the word `null` and non-blank fields not being populated when adding new partners during a gift import from the gift import app.

**Records in the new partner app before this change**:
<img width="1109" height="862" alt="image" src="https://github.com/user-attachments/assets/d2f1feb9-6581-4dd7-a04f-703f4008e60a" />

**Records in the new partner app after this change**:
<img width="1104" height="860" alt="image" src="https://github.com/user-attachments/assets/fbde2811-7b1b-4454-a934-bd9ef57cade4" />
