### PR TITLE
Add "Hide Done Tasks" Checkbox to Task Board

### DIFF
--- a/kardia-app/modules/task/myprojects.cmp
+++ b/kardia-app/modules/task/myprojects.cmp
@@ -1636,16 +1636,59 @@ myprojects "widget/component-decl"
 		    height=694;
 		    spacing=10;
 
-		    tasks_label_pane "widget/component"
+		    tasks_label_pane "widget/pane"
 			{
 			height=26;
-			path="/apps/kardia/modules/task/label_pane.cmp";
-			text=runclient(:project_osrc:t_project_label + ' Tasks');
+			style=flat;
+			background="/apps/kardia/images/bg/lsblue_gradient.png";
+			border_radius=6;
+
+			tasks_label "widget/label"
+			    {
+			    x=9; y=2;
+			    width=820;
+			    height=18;
+			    style=bold;
+			    font_size=18;
+			    value=runclient(:project_osrc:t_project_label + ' Tasks');
+			    }
+
+			hide_done_label "widget/label"
+			    {
+			    x=875; y=4; width=80; height=18;
+			    align=right; style=bold;
+			    value=runclient('Hide done tasks');
+			    }
+
+			hide_done_cb "widget/checkbox"
+			    {
+			    x=956; y=5; width=16;
+
+			    hide_done_cb_hints "widget/hints"
+				{
+				style=notnull;
+				default=0;
+				}
+
+			    refresh_tasks_osrc_on_change "widget/connector"
+				{
+				event=DataChange;
+				target=tasks_osrc;
+				action=Refresh;
+				}
+			    }
 			}
 
 		    tasks_osrc "widget/osrc"
 			{
 			task_proj "widget/parameter" { type=integer; param_name=t_project_id; }
+			task_hidedone "widget/parameter"
+			    {
+			    type=integer;
+			    param_name=hide_done;
+			    default=runclient(isnull(:hide_done_cb:value, 0));
+			    }
+
 			sql = "	select
 				    *,
 				    nametxt = :t:t_task_label + condition(:parameters:t_project_id = 0, ' (' + (select :t_project_label from /apps/kardia/data/Kardia_DB/t_project/rows pr where :pr:t_project_id = :t:t_project_id) + ')', ''),
@@ -1656,7 +1699,8 @@ myprojects "widget/component-decl"
 				from
 				    /apps/kardia/data/Kardia_DB/t_task/rows t
 				where
-				    :t:t_project_id = :parameters:t_project_id or :parameters:t_project_id = 0
+				    (:t:t_project_id = :parameters:t_project_id or :parameters:t_project_id = 0) and
+				    (:parameters:hide_done = 0 or isnull(:t:t_task_percent, 0.0) < 1.0)
 				";
 			baseobj="/apps/kardia/data/Kardia_DB/t_task/rows";
 			replicasize=200;

--- a/kardia-app/modules/task/myprojects.cmp
+++ b/kardia-app/modules/task/myprojects.cmp
@@ -1643,38 +1643,41 @@ myprojects "widget/component-decl"
 			background="/apps/kardia/images/bg/lsblue_gradient.png";
 			border_radius=6;
 
-			tasks_label "widget/label"
+			tasks_labels_hbox "widget/hbox"
 			    {
-			    x=9; y=2;
-			    width=820;
-			    height=18;
-			    style=bold;
-			    font_size=18;
-			    value=runclient(:project_osrc:t_project_label + ' Tasks');
-			    }
+			    x=10; y=0; width=960; height=26; fl_width=100; spacing=10;
 
-			hide_done_label "widget/label"
-			    {
-			    x=875; y=4; width=80; height=18;
-			    align=right; style=bold;
-			    value=runclient('Hide done tasks');
-			    }
-
-			hide_done_cb "widget/checkbox"
-			    {
-			    x=956; y=5; width=16;
-
-			    hide_done_cb_hints "widget/hints"
+			    tasks_label "widget/label"
 				{
-				style=notnull;
-				default=0;
+				y=2; width=810; height=18; fl_width=100; // x = tasks_labels_hbox
+				style=bold;
+				font_size=18;
+				value=runclient(:project_osrc:t_project_label + ' Tasks');
 				}
 
-			    refresh_tasks_osrc_on_change "widget/connector"
+			    hide_done_label "widget/label"
 				{
-				event=DataChange;
-				target=tasks_osrc;
-				action=Refresh;
+				y=5; width=100; height=18; fl_width=0; // x = tasks_labels_hbox
+				align=right; style=bold;
+				value=runclient('Hide done tasks');
+				}
+
+			    hide_done_cb "widget/checkbox"
+				{
+				y=5; width=15; fl_width=0; // x = tasks_labels_hbox
+
+				hide_done_cb_hints "widget/hints"
+				    {
+				    style=notnull;
+				    default=0;
+				    }
+
+				refresh_tasks_osrc_on_change "widget/connector"
+				    {
+				    event=DataChange;
+				    target=tasks_osrc;
+				    action=Refresh;
+				    }
 				}
 			    }
 			}
@@ -2625,4 +2628,3 @@ myprojects "widget/component-decl"
 	    }
 	}
     }
-


### PR DESCRIPTION
This PR will add a "hide done tasks" checkbox to the task page of the taskboard.

I hacked together a really janky JS script during Code-a-Thon 2025 that I could paste into my console every time I went to this tab that would do this. After the interns had the same issue, I decided I'd finally fix it. With this PR, there will finally be an official, far-more-user-friendly solution.