### PR TITLE
Fix Window Attachment

### DIFF
--- a/kardia-app/modules/crm/crm.cmp
+++ b/kardia-app/modules/crm/crm.cmp
@@ -222,8 +222,7 @@ crm "widget/component-decl"
 		event_condition=runclient(:Button == 'Menu');
 		target=menu_overlay;
 		action=Open;
-		open_x=runclient(:crm_layout:width - 198);
-		open_y=76;
+		origin=runclient(:Origin);
 		collaborator=runclient(:collaborator_osrc:p_partner_key);
 		}
 	    }

--- a/kardia-app/modules/crm/menu.cmp
+++ b/kardia-app/modules/crm/menu.cmp
@@ -7,15 +7,14 @@ menu "widget/component-decl"
     // Triggered when a menu item is selected
     ItemSelected "widget/component-decl-event" { }
 
-    // Opens / displays the menu
+    // Opens / displays the menu.  Pass the widget it should pop up against.
     Open "widget/component-decl-action" { }
     onOpen "widget/connector"
 	{
 	event=Open;
 	target=menu_window;
 	action=Popup;
-	X=runclient(:open_x);
-	Y=runclient(:open_y);
+	PopTo=runclient(:origin);
 	}
 
     // Closes / hides the menu

--- a/kardia-app/modules/task/menu.cmp
+++ b/kardia-app/modules/task/menu.cmp
@@ -5,6 +5,9 @@ menu "widget/component-decl"
     height=98;
     widget_template = "/apps/kardia/modules/task/tasks.tpl";
 
+    // The widget the menu pops up against, passed in by whoever uses the menu.
+    attach_to "widget/parameter" { type=object; default=null; }
+
     // Triggered when a menu item is selected
     ItemSelected "widget/component-decl-event" { }
 
@@ -15,8 +18,7 @@ menu "widget/component-decl"
 	event=Open;
 	target=menu_window;
 	action=Popup;
-	X=runclient(:open_x);
-	Y=runclient(:open_y);
+	PopTo=attach_to;
 	}
 
     // Closes / hides the menu

--- a/kardia-app/modules/task/myprojects.cmp
+++ b/kardia-app/modules/task/myprojects.cmp
@@ -35,6 +35,7 @@ myprojects "widget/component-decl"
 	{
 	x=800; y=0; width=200; height=98;
 	path="menu.cmp";
+	attach_to=menu_btn;
 
 	onItemSelect_1 "widget/connector" { event=ItemSelected; target=menu_overlay; action=Close; }
 	onItemSelect_Logout "widget/connector"
@@ -515,8 +516,6 @@ myprojects "widget/component-decl"
 			    event=Click; 
 			    target=menu_overlay;
 			    action=Open;
-			    open_x=runclient(:main_vbox:width - 198);
-			    open_y=76;
 			    }
 			}
 		    }
@@ -2581,4 +2580,3 @@ myprojects "widget/component-decl"
 	    }
 	}
     }
-


### PR DESCRIPTION
This PR appears to have minimal impact when using the latest Centrallix build on `master`. However, when using the Centrallix `apos_autoscale9-slim5` build, the attributes it passes are important to ensuring that dropdown menus do not detach from their buttons when the view port is resized on the client.